### PR TITLE
modifying the Readmes

### DIFF
--- a/GitHubTeamManager/README.md
+++ b/GitHubTeamManager/README.md
@@ -1,15 +1,16 @@
 # GitHub Team Manager
 
-This application synchronizes IdP groups with GitHub Teams using the SCIM API. It performs two main functions:
-1. Fetches all groups from the IdP using the SCIM endpoint
-2. Creates corresponding GitHub Teams and links them to the IdP groups
+This application automates team management in GitHub Enterprise by fetching external groups through the GitHub Teams External Groups API (for EMU accounts). It performs two main functions:
+1. Retrieves external groups from the GitHub Enterprise instance
+2. Creates and links GitHub Teams to these external groups automatically
+3. Ignores IdP groups if a Team already exists with that group name
 
 ## Prerequisites
 
 - .NET 8.0 SDK or later
-- GitHub Organization with SCIM provisioning enabled
-- GitHub Personal Access Token with appropriate permissions
-- SCIM Token for your IdP
+- GitHub Enterprise EMU account
+- GitHub Personal Access Token with `admin:org` scope
+- Organization admin access
 
 ## Configuration
 
@@ -17,19 +18,19 @@ Create an `appsettings.json` file in the project directory with the following st
 
 ```json
 {
-  "GitHubToken": "your-github-token",
-  "GitHubOrganization": "your-organization-name",
-  "SCIMToken": "your-scim-token",
-  "SCIMBaseUrl": "your-scim-base-url"
+  "GitHub": {
+    "Token": "your-github-token",
+    "OrganizationName": "your-organization-name",
+    "BaseUrl": "https://api.github.com"
+  }
 }
 ```
 
 Replace the placeholder values with your actual configuration:
 
-- `GitHubToken`: A GitHub Personal Access Token with `admin:org` scope
-- `GitHubOrganization`: Your GitHub organization name
-- `SCIMToken`: The SCIM token provided by your IdP
-- `SCIMBaseUrl`: The base URL for SCIM API endpoints
+- `Token`: A GitHub Personal Access Token with `admin:org` scope
+- `OrganizationName`: Your GitHub organization name
+- `BaseUrl`: The base URL for GitHub's API (defaults to https://api.github.com)
 
 ## Building the Application
 

--- a/README.md
+++ b/README.md
@@ -24,21 +24,19 @@ Create an `appsettings.json` file in the application directory with the followin
 
 ```json
 {
-  "GitHubToken": "your-github-token",
-  "EnterpriseSlug": "your-enterprise-slug",
-  "GitHubOrganization": "your-organization-name",
-  "SCIMToken": "your-scim-token",
-  "SCIMBaseUrl": "https://api.github.com"
+  "GitHub": {
+    "Token": "your-github-token",
+    "OrganizationName": "your-organization-name",
+    "BaseUrl": "https://api.github.com"
+  }
 }
 ```
 
 ### Required Settings
 
-- `GitHubToken`: A GitHub Personal Access Token with `admin:org` scope
-- `EnterpriseSlug`: Your GitHub Enterprise slug (URL-friendly name)
-- `GitHubOrganization`: The name of your GitHub organization
-- `SCIMToken`: The SCIM token provided by your IdP
-- `SCIMBaseUrl`: The base URL for GitHub's API (usually https://api.github.com)
+- `GitHub:Token`: A GitHub Personal Access Token with `admin:org` scope
+- `GitHub:OrganizationName`: The name of your GitHub organization
+- `GitHub:BaseUrl`: The base URL for GitHub's API (defaults to https://api.github.com)
 
 ## Building and Running
 
@@ -54,11 +52,11 @@ dotnet run
 
 ## How It Works
 
-1. The application connects to GitHub's SCIM API to fetch all available enterprise groups
-2. For each SCIM group:
+1. The application connects to GitHub's External Groups API to fetch all available external groups
+2. For each external group:
    - Checks if a corresponding GitHub team exists
    - If no team exists, creates a new team with matching name
-   - Links the team (new or existing) to the SCIM group using GitHub's external groups API
+   - Links the team (new or existing) to the external group using GitHub's Teams API
 3. Provides detailed logging of all operations
 
 ## Error Handling


### PR DESCRIPTION
This pull request updates the `GitHubTeamManager` documentation to reflect changes in the application's functionality and configuration, particularly the transition from using the SCIM API to the External Groups API for GitHub Enterprise. It also updates configuration details to align with the new API usage.

### Updates to functionality:
* The application now fetches external groups using the GitHub External Groups API instead of the SCIM API, specifically for GitHub Enterprise EMU accounts. It creates and links GitHub Teams to these external groups and ignores groups if a team with the same name already exists. (`README.md`, [[1]](diffhunk://#diff-c32e2fa7d8392591f0cb31d851fff5e7f9ab41f0451455849f0e1010e868fa90L3-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R59)

### Configuration changes:
* The structure of `appsettings.json` has been updated to group GitHub-related settings under a single `GitHub` object, simplifying configuration. (`README.md`, [[1]](diffhunk://#diff-c32e2fa7d8392591f0cb31d851fff5e7f9ab41f0451455849f0e1010e868fa90L3-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R39)

### Documentation improvements:
* Updated prerequisites to reflect the new API and permissions required (`admin:org` scope and GitHub Enterprise EMU account). (`README.md`, [GitHubTeamManager/README.mdL3-R33](diffhunk://#diff-c32e2fa7d8392591f0cb31d851fff5e7f9ab41f0451455849f0e1010e868fa90L3-R33))
* Clarified required settings and their usage in the updated configuration format. (`README.md`, [README.mdL27-R39](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R39))